### PR TITLE
Enable smart suggestions and completions in Visual Studio Code JavaScript projects

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+/// <reference path="../node_modules/tns-core-modules/tns-core-modules.d.ts" /> Enable smart suggestions and completions in Visual Studio Code JavaScript projects.
 var application = require("application");
 application.mainModule = "main-page";
 application.cssFile = "./app.css";


### PR DESCRIPTION
The language service of my Visual Studio Code ignores the node_modules and does not pick .d.ts-es from the tns-core-modules. The reference line enables the smart code completions and suggestions in all .js files within the app. It may become redundant in future versions of Visual Studio Code but for now it brings in a lot of value along the .d.ts-es we will ship with v1.5.0.