### PR TITLE
Set license to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "1.5.0",
 	"author": "Telerik <support@telerik.com>",
 	"description": "Nativescript hello-world project template",
-	"license": "BSD",
+	"license": "Apache-2.0",
 	"keywords": [
 		"telerik",
 		"mobile",


### PR DESCRIPTION
Set license to Apache-2.0 in package.json. It was incorrectly set to BSD.