### PR TITLE
Move autocompletion reference to separate file

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-/// <reference path="../node_modules/tns-core-modules/tns-core-modules.d.ts" /> Enable smart suggestions and completions in Visual Studio Code JavaScript projects.
 var application = require("application");
 application.mainModule = "main-page";
 application.cssFile = "./app.css";

--- a/references.d.ts
+++ b/references.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../node_modules/tns-core-modules/tns-core-modules.d.ts" /> Enable smart suggestions and completions in Visual Studio Code JavaScript projects.


### PR DESCRIPTION
In order to enable autocompletion on VS Code, we have reference to `../node_modules/tns-core-modules/tns-core-modules.d.ts` inside `app.js`.
Move this reference to separate file, so in AppBuilder templates we will be able to remove the file safely.
Also client's app.js files will be cleaner.
Autocompletion will still work.