### PR TITLE
Place full AndroidManifest.xml in App_Resources

### DIFF
--- a/App_Resources/Android/AndroidManifest.xml
+++ b/App_Resources/Android/AndroidManifest.xml
@@ -1,5 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest 
-  xmlns:android="http://schemas.android.com/apk/res/android">
-  
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	package="__PACKAGE__"
+	android:versionCode="1"
+	android:versionName="1.0" >
+
+	<supports-screens
+		android:smallScreens="true"
+		android:normalScreens="true"
+		android:largeScreens="true"
+		android:xlargeScreens="true"/>
+
+	<uses-sdk
+		android:minSdkVersion="17"
+		android:targetSdkVersion="__APILEVEL__"/>
+
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+	<uses-permission android:name="android.permission.INTERNET"/>
+
+	<application
+		android:name="com.tns.NativeScriptApplication"
+		android:allowBackup="true"
+		android:icon="@drawable/icon"
+		android:label="@string/app_name"
+		android:theme="@style/AppTheme" >
+		<activity
+			android:name="com.tns.NativeScriptActivity"
+			android:label="@string/title_activity_kimera"
+			android:configChanges="keyboardHidden|orientation|screenSize">
+
+				<intent-filter>
+				<action android:name="android.intent.action.MAIN" />
+
+				<category android:name="android.intent.category.LAUNCHER" />
+			</intent-filter>
+		</activity>
+		<activity android:name="com.tns.ErrorReportActivity"/>
+	</application>
 </manifest>


### PR DESCRIPTION
According to some changes in NS CLI, we now require the full AndroidManifest.xml to be placed in App_Resources of the project.
Update the template with latest AndroidManifest.xml from https://github.com/NativeScript/android-runtime/blob/master/build/project-template-gradle/src/main/AndroidManifest.xml