### PR TITLE
Add iOS images to Info.plist

### DIFF
--- a/App_Resources/iOS/Info.plist
+++ b/App_Resources/iOS/Info.plist
@@ -8,6 +8,25 @@
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string>icon.png</string>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconFiles</key>
+			<array>
+				<string>icon-40</string>
+				<string>icon-60</string>
+				<string>icon-72</string>
+				<string>icon-76</string>
+				<string>Icon-Small</string>
+				<string>Icon-Small-50</string>
+			</array>
+			<key>UIPrerenderedIcon</key>
+			<false/>
+		</dict>
+	</dict>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -24,6 +43,8 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
In addition, set the `UIRequiresFullScreen` key to `true`.
Both of these actions are taken in order to make the template submittable to the App Store.
References: https://github.com/NativeScript/nativescript-cli/issues/1490 and part of https://github.com/NativeScript/nativescript-cli/issues/649
Ping @fealebenpae @PanayotCankov @rosen-vladimirov @ligaz 