### PR TITLE
Add build.xcconfig

### DIFF
--- a/App_Resources/iOS/build.xcconfig
+++ b/App_Resources/iOS/build.xcconfig
@@ -1,0 +1,3 @@
+// You can add custom settings here
+// for example you can uncomment the following line to force distribution code signing
+// CODE_SIGN_IDENTITY = iPhone Distribution 

--- a/App_Resources/iOS/build.xcconfig
+++ b/App_Resources/iOS/build.xcconfig
@@ -1,3 +1,5 @@
 // You can add custom settings here
 // for example you can uncomment the following line to force distribution code signing
 // CODE_SIGN_IDENTITY = iPhone Distribution 
+// ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+// ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = Brand Assets;


### PR DESCRIPTION
So that users don't have to manually create one themselves - they can just use the one that comes with the template.
Ping @PanayotCankov @rosen-vladimirov for opinions about this