### PR TITLE
Add missing error activity style

### DIFF
--- a/App_Resources/Android/values/styles.xml
+++ b/App_Resources/Android/values/styles.xml
@@ -42,4 +42,12 @@
 
     <style name="NativeScriptToolbarStyle" parent="NativeScriptToolbarStyleBase">
     </style>
+
+    <style name="NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+
+    <style name="ExceptionActionBar" parent="Theme.AppCompat.DayNight.DarkActionBar">
+    </style>
 </resources> 


### PR DESCRIPTION
Recent changes to project template include new layouts which consume new styles. These need to be included.

@dtopuzov 