### PR TITLE
app.css rules structure

### DIFF
--- a/app.css
+++ b/app.css
@@ -5,16 +5,17 @@ http://docs.nativescript.org/ui/styling for a full list of the CSS
 selectors and properties you can use to style UI components.
 
 /*
-For example, the following CSS rule changes the font size of all UI
+In many cases you may want to use the NativeScript core theme instead
+of writing your own CSS rules. For a full list of class names in the theme
+refer to http://docs.nativescript.org/ui/theme. 
+The imported CSS rules must precede all other types of rules.
+*/
+@import 'nativescript-theme-core/css/core.light.css';
+
+/*
+The following CSS rule changes the font size of all UI
 components that have the btn class name.
 */
 .btn {
     font-size: 18;
 }
-
-/*
-In many cases you may want to use the NativeScript core theme instead
-of writing your own CSS rules. For a full list of class names in the theme
-refer to http://docs.nativescript.org/ui/theme.
-*/
-@import 'nativescript-theme-core/css/core.light.css';


### PR DESCRIPTION
imported CSS must precede any other rules - related to [https://github.com/NativeScript/NativeScript/issues/4323#issuecomment-306716778](https://github.com/NativeScript/NativeScript/issues/4323#issuecomment-306716778)