### PR TITLE
refactor(deps): remove explicit tns-core-modules dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
 		"v8Flags": "--expose_gc"
 	},
 	"dependencies": {
-		"nativescript-theme-core": "~1.0.4",
-		"tns-core-modules": "next"
+		"nativescript-theme-core": "~1.0.4"
 	}
 }


### PR DESCRIPTION
Remove explicit tns-core-modules dependency and let CLI handle it.

NOTE: We need tns-core-modules@4.0.0 live -- otherwise this will fail the `master` branch.